### PR TITLE
Fix crash with FileNotFoundException upon saving log file from Diagnostics for empty (0 byte) log file.

### DIFF
--- a/app/src/main/kotlin/ee/ria/DigiDoc/fragment/screen/DiagnosticsScreen.kt
+++ b/app/src/main/kotlin/ee/ria/DigiDoc/fragment/screen/DiagnosticsScreen.kt
@@ -312,15 +312,15 @@ fun DiagnosticsScreen(
                     title = R.string.main_diagnostics_save_log,
                     onClickItem = {
                         try {
-                            val diagnosticsFile = diagnosticsViewModel.createLogFile()
-                            actionFile = diagnosticsFile
+                            val logFile = diagnosticsViewModel.createLogFile()
+                            actionFile = logFile
                             val saveIntent =
                                 Intent.createChooser(
                                     Intent(Intent.ACTION_CREATE_DOCUMENT)
                                         .addCategory(Intent.CATEGORY_OPENABLE)
                                         .putExtra(
                                             Intent.EXTRA_TITLE,
-                                            sanitizeString(diagnosticsFile.name, ""),
+                                            sanitizeString(logFile.name, ""),
                                         )
                                         .setType("text/x-log")
                                         .addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION),

--- a/app/src/main/kotlin/ee/ria/DigiDoc/viewmodel/DiagnosticsViewModel.kt
+++ b/app/src/main/kotlin/ee/ria/DigiDoc/viewmodel/DiagnosticsViewModel.kt
@@ -56,8 +56,10 @@ class DiagnosticsViewModel
         val context: LiveData<Context> = _context
 
         private val logTag = "SettingsViewModel"
-        private val diagnosticsFileName =
+        private val logsFileName =
             "ria_digidoc_${getAppVersion()}.${getAppVersionCode()}_logs.log"
+        private val diagnosticsFileName =
+            "ria_digidoc_${getAppVersion()}.${getAppVersionCode()}_diagnostics.log"
         private val diagnosticsFilePath: String = File(getCurrentContext().filesDir.path, "diagnostics").path
 
         private val _updatedConfiguration = MutableLiveData<ConfigurationProvider?>()
@@ -189,7 +191,7 @@ class DiagnosticsViewModel
             if (FileUtil.logsExist(FileUtil.getLogsDirectory(getCurrentContext()))) {
                 return FileUtil.combineLogFiles(
                     FileUtil.getLogsDirectory(getCurrentContext()),
-                    diagnosticsFileName,
+                    logsFileName,
                 )
             }
             throw FileNotFoundException("Unable to get directory with logs")

--- a/utils-lib/src/main/kotlin/ee/ria/DigiDoc/utilsLib/file/FileUtil.kt
+++ b/utils-lib/src/main/kotlin/ee/ria/DigiDoc/utilsLib/file/FileUtil.kt
@@ -209,7 +209,7 @@ object FileUtil {
             }
             if (files != null) {
                 for (file in files) {
-                    if (file.length() > 0 && (file.extension == "log")) {
+                    if (file.extension == "log") {
                         val header = """
 
 ===== File: ${file.getName()} =====


### PR DESCRIPTION
- MOPPAND-1392

_Fix crash with FileNotFoundException upon saving log file from Diagnostics for empty (0 byte) log file._

Signed-off-by: Boriss Melikjan <boriss.melikjan@nortal.com>
