### PR TITLE
Fix mark as secure setting to be false for debug builds.

### DIFF
--- a/app/src/main/kotlin/ee/ria/DigiDoc/utils/secure/SecureUtil.kt
+++ b/app/src/main/kotlin/ee/ria/DigiDoc/utils/secure/SecureUtil.kt
@@ -7,7 +7,7 @@ import android.content.SharedPreferences
 import android.view.Window
 import android.view.WindowManager
 import androidx.preference.PreferenceManager
-import com.takisoft.preferencex.BuildConfig
+import ee.ria.DigiDoc.BuildConfig
 import ee.ria.DigiDoc.R
 
 object SecureUtil {


### PR DESCRIPTION
**MOPPAND-1402**

Fix mark as secure setting to be false for debug builds.

Signed-off-by: Boriss Melikjan <boriss.melikjan@nortal.com>
