### PR TITLE
Remove support for Android 11, and set Target SDK to Android API 35.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 compileSdkVersion = "35"
 minSdkVersion = "31"
 targetSdkVersion = "35"
-versionCode = "65"
+versionCode = "66"
 versionName = "3.0.0"
 
 agp = "8.7.2"


### PR DESCRIPTION
**MOPPAND-1421**

- Remove support for Android 11.
- Set Target SDK to Android API 35.

Signed-off-by: Boriss Melikjan <boriss.melikjan@nortal.com>
