### PR TITLE
Fix to resolve conflicts with switching CDOC2 feature and CryptoLib encryption.

### DIFF
--- a/commons-lib/src/main/kotlin/ee/ria/DigiDoc/common/Constant.kt
+++ b/commons-lib/src/main/kotlin/ee/ria/DigiDoc/common/Constant.kt
@@ -115,7 +115,7 @@ object Constant {
     const val CDOC1_EXTENSION = "cdoc"
 
     // TODO: Change to "cdoc2" when enabled
-    const val CDOC2_EXTENSION = "cdoc"
+    const val CDOC2_EXTENSION = "cdocna"
 
     const val LDAP_PORT = 636
     const val CERT_BINARY_ATTR = "userCertificate;binary"


### PR DESCRIPTION
**MOPPAND-1648** 

- Fix to resolve conflicts with switching CDOC2 feature and CryptoLib encryption.

Signed-off-by: Boriss Melikjan <boriss.melikjan@nortal.com>
