### PR TITLE
Fix for empty Proxy port crash (check connectivity).

### DIFF
--- a/app/src/main/kotlin/ee/ria/DigiDoc/fragment/screen/ProxyServicesSettingsScreen.kt
+++ b/app/src/main/kotlin/ee/ria/DigiDoc/fragment/screen/ProxyServicesSettingsScreen.kt
@@ -743,10 +743,11 @@ fun ProxyServicesSettingsScreen(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 TextButton(onClick = {
+                    val proxyPort = proxyPort.text.toIntOrNull() ?: 80
                     sharedSettingsViewModel.checkConnection(
                         ManualProxy(
                             host = proxyHost.text,
-                            port = proxyPort.text.toInt(),
+                            port = proxyPort,
                             username = proxyUsername.text,
                             password = proxyPassword.text,
                         ),


### PR DESCRIPTION
**MOPPAND-1699** 

- Fix for empty Proxy port crash (check connectivity).

Signed-off-by: Boriss Melikjan <boriss.melikjan@nortal.com>
